### PR TITLE
Solution of problem number 2643

### DIFF
--- a/lib/List_solutions/row_with_maximum_ones_2643.ex
+++ b/lib/List_solutions/row_with_maximum_ones_2643.ex
@@ -1,0 +1,29 @@
+defmodule RowAndMaximumOnes do
+  defstruct index: 0, previous_ones_count: 0
+  @spec row_and_maximum_ones(mat :: [[integer]]) :: [integer]
+  def row_and_maximum_ones(mat) do
+    mat
+    |> Enum.with_index()
+    |> max_ones(%RowAndMaximumOnes{})
+  end
+
+  defp max_ones([], %{index: index_num, previous_ones_count: prev_count} = info),
+    do: [index_num, prev_count]
+
+  defp max_ones(
+         [{list, index} | tail],
+         %{index: index_num, previous_ones_count: prev_count} = info
+       ) do
+    current_ones =
+      list
+      |> Enum.count(fn num -> num == 1 end)
+
+    info =
+      cond do
+        current_ones > prev_count -> %{info | index: index, previous_ones_count: current_ones}
+        true -> info
+      end
+
+    max_ones(tail, info)
+  end
+end


### PR DESCRIPTION
Given a m x n binary matrix mat, find the 0-indexed position of the row that contains the maximum count of ones, and the number of ones in that row.

In case there are multiple rows that have the maximum count of ones, the row with the smallest row number should be selected.

Return an array containing the index of the row, and the number of ones in it.

Input: mat = [[0,1],[1,0]]
Output: [0,1]
Explanation: Both rows have the same number of 1's. So we return the index of the smaller row, 0, and the maximum count of ones (1). So, the answer is [0,1]. 

Can you help me optimize the code of the above question and let me know if there are changes in the naming convention... 